### PR TITLE
const in strict mode fix

### DIFF
--- a/hastebin/Dockerfile
+++ b/hastebin/Dockerfile
@@ -1,12 +1,11 @@
-FROM debian:jessie
+FROM node:5.4
 
 MAINTAINER Ric Lister, rlister@gmail.com
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
     apt-get install -yq \
-    git \
-    nodejs npm
+    git
 
 RUN git clone https://github.com/seejohnrun/haste-server.git /app
 WORKDIR /app

--- a/hastebin/app.sh
+++ b/hastebin/app.sh
@@ -34,4 +34,4 @@ cat > config.js <<EOF
 EOF
 
 ## run the server
-exec /usr/bin/nodejs ./server.js
+exec /usr/local/bin/node ./server.js


### PR DESCRIPTION
Works around [haste-server issue 97](https://github.com/seejohnrun/ha…ste-server/issues/97) by using a new node version.

Out of the box, this image has stopped working; Debian's change.
