### PR TITLE
Specify compatible version of fog for riemann-dash

### DIFF
--- a/riemann-dash/Dockerfile
+++ b/riemann-dash/Dockerfile
@@ -7,7 +7,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install -y \
     ca-certificates
 
-RUN gem install --no-rdoc --no-ri riemann-dash thin fog
+RUN gem install --no-rdoc --no-ri riemann-dash thin 
+RUN gem install --no-rdoc --no-ri fog -v 1.19.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Thanks for sharing your Dockerfiles!

Riemann Dash includes a dependency on multi-json [version 1.3.6](https://github.com/riemann/riemann-dash/blob/master/riemann-dash.gemspec#L22)

The latest version of the fog gem includes a dependency on a later version of multi-json and so recent builds of this docker container contain incompatible gems.

To fix, I've specified that version 1.19.0 of the fog gem should be installed.
