### PR TITLE
Set default STORAGE_TYPE to file

### DIFF
--- a/hastebin/Dockerfile
+++ b/hastebin/Dockerfile
@@ -16,4 +16,6 @@ RUN chmod 755 app.sh
 
 EXPOSE 7777
 
+ENV STORAGE_TYPE file
+
 CMD [ "./app.sh" ]

--- a/hastebin/README.md
+++ b/hastebin/README.md
@@ -11,6 +11,8 @@ See `app.sh` for variable names.
 
 ## Example use
 
+> `STORAGE_TYPE` is set to `file` by default so you can quickly be up and running!
+
 Writing pastes to a mounted local volume:
 
 ```


### PR DESCRIPTION
Since most people usually just want a sane default, this PR adds a `file` default so the container can launch and stay running without any further user intervention. 

I love this image and use it all the time for testing here and there ;)
