### PR TITLE
hastebin: add STORAGE_TYPE=redis to command

### DIFF
--- a/hastebin/README.md
+++ b/hastebin/README.md
@@ -23,5 +23,5 @@ Writing pastes to redis:
 
 ```
 docker run --name redis -d redis
-docker run --name hastebin -d -p 7777:7777 --link redis:redis -e STORAGE_HOST=redis rlister/hastebin
+docker run --name hastebin -d -p 7777:7777 --link redis:redis -e STORAGE_TYPE=redis -e STORAGE_HOST=redis rlister/hastebin
 ```


### PR DESCRIPTION
Without this hastebin will use file storage by default as mentioned already in the README. So you need to specify both `STORAGE_TYPE` and `STORAGE_HOST`.