### PR TITLE
bugfix docker-compose in README.md for redis entrypoint

### DIFF
--- a/hastebin/README.md
+++ b/hastebin/README.md
@@ -50,5 +50,5 @@ services:
     image: redis
     volumes:
       - ./data:/data
-entrypoint: redis-server --appendonly yes
+    entrypoint: redis-server --appendonly yes
 ```


### PR DESCRIPTION
the example in the README has an error

```
docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
Invalid top-level property "entrypoint". Valid top-level sections for this Compose file are: version, services, networks, volumes, and extensions starting with "x-".

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```